### PR TITLE
Purpose readme contribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,13 @@ alert("Since webworkers are async this should happen first.\nThe callbacks may f
 
 The astute may realize that they can access the `event` variable inside the callback.  
 Also since the callback is stringified and injected into the webworker, you don't have access to any vars in scope
+
+## What to Use webwork.js for and When to Use It
+webwork.js is best used for any project that requires web workers, but needs to minimize or eleminate external web worker files. It also allows for simpler, cleaner inline web worker code. webwork.js should be used when a project: 
+- needs web workers, but wants to keep web worker code inline for minification and distribution purposes
+- needs web workers, but wants to keep web worker code inline to avoid excessive external web worker files and page requests
+- needs inline web workers, and wants to avoid repetitive and tedious [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob) code
+
+
+
+


### PR DESCRIPTION
To make webwork.js more approachable to a larger number of users—from informed developers to curious passersby and new and interested visitors—I have added a new section to the webwork.js README. The section is entitled *What to Use webwork.js for and When to Use It*. As the name suggests, the new section, a brief paragraph, explains in plain and straightforward language what webwork.js is used for and when one should use it.

Thanks, 
Brian